### PR TITLE
Ticket #23 - view users profiles

### DIFF
--- a/TabloidMVC/Controllers/AccountController.cs
+++ b/TabloidMVC/Controllers/AccountController.cs
@@ -55,5 +55,11 @@ namespace TabloidMVC.Controllers
             await HttpContext.SignOutAsync();
             return RedirectToAction("Index", "Home");
         }
+
+        public IActionResult Index()
+        {
+            List<UserProfile> users = _userProfileRepository.GetAllUserProfiles();
+            return View(users);
+        }
     }
 }

--- a/TabloidMVC/Repositories/IUserProfileRepository.cs
+++ b/TabloidMVC/Repositories/IUserProfileRepository.cs
@@ -1,9 +1,12 @@
-﻿using TabloidMVC.Models;
+﻿using System.Collections.Generic;
+using TabloidMVC.Models;
 
 namespace TabloidMVC.Repositories
 {
     public interface IUserProfileRepository
     {
         UserProfile GetByEmail(string email);
+        List<UserProfile> GetAllUserProfiles();
+        UserProfile GetUserById(int id);
     }
 }

--- a/TabloidMVC/Views/Account/Index.cshtml
+++ b/TabloidMVC/Views/Account/Index.cshtml
@@ -1,0 +1,47 @@
+﻿@model IEnumerable<TabloidMVC.Models.UserProfile>
+
+@{
+    ViewData["Title"] = "Index";
+}
+
+<h1>Index</h1>
+
+<p>
+    <a asp-action="Create">Create New</a>
+</p>
+<table class="table">
+    <thead>
+        <tr>
+            <th>
+                Full Name
+            </th>
+            <th>
+                Display Name
+            </th>
+            <th>
+                User Type
+            </th>          
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+@foreach (var item in Model) {
+        <tr>
+            <td>
+                @Html.DisplayFor(modelItem => item.FullName)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.DisplayName)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.UserType.Name)
+            </td>
+           @* <td>
+                @Html.ActionLink("Edit", "Edit", new { /* id=item.PrimaryKey */ }) |
+                @Html.ActionLink("Details", "Details", new { /* id=item.PrimaryKey */ }) |
+                @Html.ActionLink("Delete", "Delete", new { /* id=item.PrimaryKey */ })
+            </td>*@
+        </tr>
+}
+    </tbody>
+</table>

--- a/TabloidMVC/Views/Shared/_Layout.cshtml
+++ b/TabloidMVC/Views/Shared/_Layout.cshtml
@@ -30,14 +30,18 @@
                             <li class="nav-item mx-0 mx-lg-1">
                                 <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Post" asp-action="Index">POSTS</a>
                             </li>
+                            // added this area
                             <li class="nav-item mx-0 mx-lg-1">
-                                <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Post" asp-action="MyPost">MY POSTS</a>
+                                <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Post" asp-action="Index">MY POSTS</a>
                             </li>
                             <li class="nav-item mx-0 mx-lg-1">
                                 <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Tag" asp-action="Index">TAGS</a>
                             </li>
                             <li class="nav-item mx-0 mx-lg-1">
                                 <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Category" asp-action="Index">CATEGORY MANAGEMENT</a>
+                            </li>
+                            <li class="nav-item mx-0 mx-lg-1">
+                                <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Account" asp-action="Index">USER PROFILES</a>
                             </li>
                             <li class="nav-item mx-0 mx-lg-1">
                                 <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Account" asp-action="Logout">LOGOUT</a>


### PR DESCRIPTION
https://trello.com/c/cmKmFzpi/23-23-view-all-user-profiles        Ticket #23

This Code allows for an admin user to view a list of user profiles containing the properties of full name, display name, and user type.

In AccountController, 
created an index page for Account that allows a view of the users profile.

Post Repository contains a method of GetAllIndividual posts that fetches the user's post based on their UserProfileId.


In UserProfileRepository created a method to get all of the users profiles, get the user by their id.

Added the two previous methods to the IUserProfileRepository interface.

Type of change
New feature (non-breaking change which adds functionality).
This change requires a documentation update.

Testing Instructions
Reference [How to test a teammate's PR](https://gist.github.com/jordan-castelloe/96f76d5bd4cfbd2181084af674c2a1af#when-you-need-to-test-a-teammates-pr)
Login using admin@example.
Go to the user profiles tabs on the webpage.
You should be able to view the current users registered to the database in alphabetical order of the display name.

Make sure to add all [seed data](https://github.com/NewForce-Cohort-5/tabloidmvc-the-runtime-terrors/tree/main/SQL) before testing.
Run this command below to see that the two current users in the database have different user type ids (author and admin)
SELECT u.Id, u.DisplayName, u.FirstName, u.LastName, u.Email, u.CreateDateTime, u.ImageLocation, u.UserTypeId, ut.[Name] as UserTypeName
                        FROM UserProfile u
                        LEFT JOIN UserType ut ON u.UserTypeId = ut.Id
                        ORDER BY u.DisplayName ASC

Cross check the user type names to make sure the admin and the author are correctly matched to the database, if they match the webpage then the user profiles tab is working correctly. You should only see full name, display name, and  user type name.